### PR TITLE
Improve accessibility and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,28 @@
     textarea, input { width:100%; background:#0f1129; color:#e8ecff; border:1px solid #2a2f4a; border-radius:8px; padding:8px; }
     button { cursor:pointer; border:1px solid #2a2f4a; background:#1a1f3f; color:#e8ecff; border-radius:8px; padding:8px 10px; }
     button:disabled { opacity: .6; cursor: not-allowed; }
+    :focus-visible { outline:2px solid #00d084; outline-offset:2px; }
+    .skip-link {
+      position: absolute;
+      left: -999px;
+      top: 0;
+      background: #00d084;
+      color: #000;
+      padding: 8px;
+      border-radius: 4px;
+    }
+    .skip-link:focus { left: 8px; }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
     .row { display:flex; gap:8px; align-items:center; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
     .small { font-size: 12px; opacity:.9; }
@@ -348,6 +370,8 @@
       width:200px; height:200px; border:2px solid #000;
       display:flex; align-items:center; justify-content:center;
       cursor:pointer;
+      background:#fff;
+      font: inherit;
     }
     .host-layout, .player-layout { display:flex; width:100%; height:100%; }
     .sidebar { width:120px; padding:20px; display:flex; flex-direction:column; gap:20px; }
@@ -356,6 +380,8 @@
       width:60px; height:60px; border:2px solid #000;
       display:flex; align-items:center; justify-content:center;
       text-align:center; font-size:12px; cursor:pointer;
+      background:#fff;
+      font: inherit;
     }
     .content { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:20px; }
     .wide-btn { width:60%; padding:20px; border:2px solid #000; background:#fff; text-align:center; }
@@ -364,7 +390,8 @@
   </style>
 </head>
 <body>
-  <aside>
+  <a href="#mainContent" class="skip-link">Skip to main content</a>
+  <aside aria-label="Connection controls">
     <h1>P2P over LAN, pure browser</h1>
     <div class="small muted box" style="margin-bottom:10px">
       Two roles. Host creates an offer, peer pastes it and returns an answer. No server, copy paste or QR only. Same Wi‑Fi is ideal.
@@ -382,6 +409,7 @@
           <button id="btnQrOffer" disabled>Show QR</button>
         </div>
         <div class="row">
+          <label for="offerOut" class="sr-only">Generated offer</label>
           <input id="offerOut" placeholder="Offer will appear here" readonly />
         </div>
         <div class="row">
@@ -389,9 +417,10 @@
           <button id="btnScanAnswer" disabled>Scan Answer</button>
         </div>
         <div class="row">
+          <label for="answerIn" class="sr-only">Answer from peer</label>
           <input id="answerIn" placeholder="Paste or scan answer here" />
         </div>
-        <div class="small muted" id="hostState">idle</div>
+        <div class="small muted" id="hostState" aria-live="polite">idle</div>
       </section>
 
       <section class="box">
@@ -401,6 +430,7 @@
           <button id="btnScanHost">📱 Scan Host</button>
         </div>
         <div class="row">
+          <label for="offerIn" class="sr-only">Offer from host</label>
           <input id="offerIn" placeholder="Paste or scan offer here" />
         </div>
         <div class="row">
@@ -412,20 +442,22 @@
           <button id="btnQrAnswer" disabled>Show QR</button>
         </div>
         <div class="row">
+          <label for="answerOut" class="sr-only">Generated answer</label>
           <input id="answerOut" placeholder="Answer will appear here" readonly />
         </div>
-        <div class="small muted" id="peerState">idle</div>
+        <div class="small muted" id="peerState" aria-live="polite">idle</div>
       </section>
 
       <section class="box">
         <h2>Status</h2>
-        <div class="small mono" id="status">Not connected</div>
+        <div class="small mono" id="status" aria-live="polite" role="status">Not connected</div>
         <div class="small mono" id="latency"></div>
       </section>
 
       <section class="box">
         <h2>Chat, debug</h2>
         <div class="row">
+          <label for="chatInput" class="sr-only">Chat message</label>
           <input id="chatInput" placeholder="Type a message" />
           <button id="chatSend" disabled>Send</button>
         </div>
@@ -450,55 +482,56 @@
     </div>
   </aside>
 
-  <main>
+  <main id="mainContent">
     <div id="uiContainer" class="ui-container">
       <div id="screenSelect" class="screen active">
+        <h2>Choose your role</h2>
         <div class="role-selection">
-          <div id="chooseHost" class="role-box">HOST</div>
-          <div id="choosePlayer" class="role-box">PLAYER</div>
+          <button id="chooseHost" class="role-box">Host</button>
+          <button id="choosePlayer" class="role-box">Player</button>
         </div>
       </div>
       <div id="screenHostWait" class="screen">
         <div class="host-layout">
           <div class="sidebar">
-            <div class="label">HOST</div>
-            <div id="hostQrBtn" class="qr-toggle">QR CODE<br>PRESS TO SHOW</div>
+            <div class="label">Host</div>
+            <button id="hostQrBtn" class="qr-toggle" aria-label="Show QR code">QR CODE</button>
           </div>
           <div class="content">
-            <div class="wide-btn">YOU</div>
-            <div id="hostWaitBtn" class="wide-btn">WAITING FOR AN OTHER PLAYER</div>
+            <p class="wide-btn">You</p>
+            <p id="hostStatus" class="wide-btn" role="status" aria-live="polite">Waiting for another player</p>
           </div>
         </div>
       </div>
       <div id="screenHostScan" class="screen">
         <div class="host-layout">
           <div class="sidebar">
-            <div class="label">HOST</div>
-            <div class="qr-toggle">QR CODE</div>
+            <div class="label">Host</div>
+            <button class="qr-toggle" disabled aria-disabled="true">QR CODE</button>
           </div>
           <div class="content">
-            <div class="wide-btn">YOU</div>
-            <div id="hostScanBtn" class="wide-btn">SCAN PLAYER CODE</div>
+            <p class="wide-btn">You</p>
+            <button id="hostScanBtn" class="wide-btn">Scan player code</button>
           </div>
         </div>
       </div>
       <div id="screenPlayerScan" class="screen">
         <div class="player-layout">
           <div class="player-scan">
-            <div id="playerScanBox" class="scan-box"></div>
-            <div>SCAN HOST QR CODE</div>
+            <div id="playerScanBox" class="scan-box" role="img" aria-label="Camera view for scanning"></div>
+            <p id="playerScanStatus" role="status" aria-live="polite">Scan host QR code</p>
           </div>
         </div>
       </div>
       <div id="screenPlayerReady" class="screen">
         <div class="player-layout">
           <div class="sidebar">
-            <div class="label">PLAYER</div>
-            <div id="playerShowQr" class="qr-toggle">QR CODE</div>
+            <div class="label">Player</div>
+            <button id="playerShowQr" class="qr-toggle" aria-label="Show your QR code">QR CODE</button>
           </div>
           <div class="player-scan">
-            <div class="scan-box"></div>
-            <div>SCAN HOST QR CODE</div>
+            <div class="scan-box" role="img" aria-label="Your QR code"></div>
+            <p role="status" aria-live="polite">Show this code to the host</p>
           </div>
         </div>
       </div>
@@ -511,11 +544,11 @@
         <button id="btnResetGame" disabled>Reset</button>
       </div>
     </div>
-    <canvas id="game"></canvas>
+      <canvas id="game" role="img" aria-label="Game area"></canvas>
 
     <div id="qrModal" class="qr-modal">
       <div class="qr-card">
-        <canvas id="qrCanvas" width="360" height="360"></canvas>
+          <canvas id="qrCanvas" width="360" height="360" role="img" aria-label="Connection QR code"></canvas>
         <div class="row qr-hint" style="justify-content:space-between">
           <span class="small muted">Scan with your camera, copy the text</span>
           <button id="qrClose">Close</button>
@@ -556,7 +589,7 @@
           <!-- Offer QR Section -->
           <div class="offer-section">
             <h4>Your Offer QR</h4>
-            <canvas id="quickConnectOfferQR" width="200" height="200"></canvas>
+              <canvas id="quickConnectOfferQR" width="200" height="200" role="img" aria-label="Offer QR code"></canvas>
           </div>
           
           <!-- Answer Scanning Section -->
@@ -628,19 +661,6 @@
 // Ensure QR library is loaded before proceeding
 if (typeof window.qrcode !== 'function') {
   console.error('QR library failed to load');
-  // Fallback QR implementation
-  window.qrcode = function(typeNumber, errorCorrectLevel) {
-    console.warn('Using fallback QR implementation');
-    return {
-      addData: function(data) { this.data = data; },
-      make: function() { this.made = true; },
-      getModuleCount: function() { return 21; },
-      isDark: function(row, col) { 
-        // Simple fallback pattern
-        return (row + col) % 2 === 0; 
-      }
-    };
-  };
 }
 
 // Cross-browser camera access compatibility

--- a/src/ui/qr.js
+++ b/src/ui/qr.js
@@ -1,50 +1,47 @@
 // Enhanced QR implementation with fallback and error handling
 export function drawQrToCanvas(text, canvas, scale) {
-	try {
-		// Check if QR library is available
-		if (typeof window.qrcode !== 'function') {
-			throw new Error('QR library not loaded');
-		}
+  try {
+    // Check if QR library is available
+    if (typeof window.qrcode !== 'function') {
+      throw new Error('QR library not loaded');
+    }
 
-		const qr = window.qrcode(0, 'L');
-		qr.addData(text);
-		qr.make();
-		const count = qr.getModuleCount();
-		const size = count * scale;
-		canvas.width = canvas.height = Math.max(240, size);
-		
-		const ctx = canvas.getContext('2d');
-		if (!ctx) {
-			throw new Error('Canvas 2D context not available');
-		}
-		
-		// Clear canvas with white background
-		ctx.fillStyle = '#fff';
-		ctx.fillRect(0, 0, canvas.width, canvas.height);
-		
-		const offset = Math.floor((canvas.width - size) / 2);
-		
-		// Draw QR code
-		for (let r = 0; r < count; r++) {
-			for (let c = 0; c < count; c++) {
-				ctx.fillStyle = qr.isDark(r, c) ? '#000' : '#fff';
-				ctx.fillRect(offset + c * scale, offset + r * scale, scale, scale);
-			}
-		}
-	} catch (error) {
-		console.error('QR generation failed:', error);
-		
-		// Fallback: draw a simple error pattern
-		canvas.width = canvas.height = 240;
-		const ctx = canvas.getContext('2d');
-		if (ctx) {
-			ctx.fillStyle = '#f0f0f0';
-			ctx.fillRect(0, 0, canvas.width, canvas.height);
-			ctx.fillStyle = '#666';
-			ctx.font = '16px system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif';
-			ctx.textAlign = 'center';
-			ctx.fillText('QR Code Error', canvas.width / 2, canvas.height / 2 - 10);
-			ctx.fillText('Text: ' + (text ? text.substring(0, 20) + '...' : 'empty'), canvas.width / 2, canvas.height / 2 + 10);
-		}
-	}
+    const qr = window.qrcode(0, 'L');
+    qr.addData(text);
+    qr.make();
+    const count = qr.getModuleCount();
+    const qrSize = count * scale;
+    const margin = 4 * scale; // ensure quiet zone for scanners
+    const canvasSize = Math.max(240, qrSize + margin * 2);
+    canvas.width = canvas.height = canvasSize;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Canvas 2D context not available');
+    }
+
+    // Clear canvas with white background
+    ctx.fillStyle = '#fff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    const offset = Math.floor((canvas.width - qrSize) / 2);
+
+    // Draw QR code
+    for (let r = 0; r < count; r++) {
+      for (let c = 0; c < count; c++) {
+        ctx.fillStyle = qr.isDark(r, c) ? '#000' : '#fff';
+        ctx.fillRect(offset + c * scale, offset + r * scale, scale, scale);
+      }
+    }
+  } catch (error) {
+    console.error('QR generation failed:', error);
+
+    // Clear to blank canvas so scanners do not misread errors as codes
+    canvas.width = canvas.height = 240;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- convert role-selection and host/player screens to real buttons and status messages
- add plain-language prompts and ARIA live regions for scan states
- annotate QR canvases for screen readers
- add visually hidden labels for form fields and chat input
- simplify QR fallback to blank canvas when generation fails
- normalize QR utility indentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c2e2f4488333ad1d785534d5e57e