### PR TITLE
Define getMediaDevices helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,44 +637,6 @@ if (typeof window.qrcode !== 'function') {
   console.error('QR library failed to load');
 }
 
-// Cross-browser camera access compatibility
-function getMediaDevices() {
-  return navigator.mediaDevices || 
-         navigator.getUserMedia || 
-         navigator.webkitGetUserMedia || 
-         navigator.mozGetUserMedia || 
-         navigator.msGetUserMedia;
-}
-
-function getUserMedia(constraints) {
-  const mediaDevices = getMediaDevices();
-  
-  if (mediaDevices && mediaDevices.getUserMedia) {
-    return mediaDevices.getUserMedia(constraints);
-  }
-  
-  // Fallback for older browsers
-  if (navigator.getUserMedia) {
-    return new Promise((resolve, reject) => {
-      navigator.getUserMedia(constraints, resolve, reject);
-    });
-  }
-  
-  if (navigator.webkitGetUserMedia) {
-    return new Promise((resolve, reject) => {
-      navigator.webkitGetUserMedia(constraints, resolve, reject);
-    });
-  }
-  
-  if (navigator.mozGetUserMedia) {
-    return new Promise((resolve, reject) => {
-      navigator.mozGetUserMedia(constraints, resolve, reject);
-    });
-  }
-  
-  throw new Error('Camera access not supported in this browser');
-}
-
 // Browser compatibility checks and polyfills
 function checkBrowserCompatibility() {
   const issues = [];
@@ -716,9 +678,16 @@ function checkBrowserCompatibility() {
   if (!window.devicePixelRatio) {
     window.devicePixelRatio = 1;
   }
-  
+
   // Check for camera access
-  if (!getMediaDevices()) {
+  const mediaDevices =
+    navigator.mediaDevices ||
+    navigator.getUserMedia ||
+    navigator.webkitGetUserMedia ||
+    navigator.mozGetUserMedia ||
+    navigator.msGetUserMedia;
+
+  if (!mediaDevices) {
     issues.push('Camera access not supported');
   }
   

--- a/src/main.js
+++ b/src/main.js
@@ -6,12 +6,16 @@ import { world, R, SPEED, SCORE_TO_WIN, ROUND_TIME, TAG_COOLDOWN, me, them, role
 import { drawQrToCanvas } from './ui/qr.js';
 
 // Cross-browser camera access compatibility
+function getMediaDevices() {
+  return navigator.mediaDevices ||
+         navigator.getUserMedia ||
+         navigator.webkitGetUserMedia ||
+         navigator.mozGetUserMedia ||
+         navigator.msGetUserMedia;
+}
+
 function getUserMedia(constraints) {
-  const mediaDevices = navigator.mediaDevices || 
-                       navigator.getUserMedia || 
-                       navigator.webkitGetUserMedia || 
-                       navigator.mozGetUserMedia || 
-                       navigator.msGetUserMedia;
+  const mediaDevices = getMediaDevices();
   
   if (mediaDevices && mediaDevices.getUserMedia) {
     return mediaDevices.getUserMedia(constraints);


### PR DESCRIPTION
## Summary
- define `getMediaDevices` in main module and reuse in `getUserMedia`
- remove duplicate camera helpers from `index.html` and check for media device support directly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1041d9c408333b5f2b31588fa5fba