### PR TITLE
Fix service worker registration and cache paths

### DIFF
--- a/connect.html
+++ b/connect.html
@@ -1867,6 +1867,15 @@
         stopScanner();
       }
     });
+
+    // Register service worker for offline support
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js').catch(err => {
+          console.error('Service worker registration failed:', err);
+        });
+      });
+    }
   </script>
 </body>
 </html>

--- a/game.html
+++ b/game.html
@@ -1406,6 +1406,15 @@
         togglePause();
       }
     });
+
+    // Register service worker for offline support
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js').catch(err => {
+          console.error('Service worker registration failed:', err);
+        });
+      });
+    }
   </script>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -663,6 +663,15 @@
         window.scrollTo(0, 0);
       }, 100);
     });
+
+    // Register service worker for offline support
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js').catch(err => {
+          console.error('Service worker registration failed:', err);
+        });
+      });
+    }
   </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,15 +1,15 @@
 // Service Worker for P2P WebRTC Game
 const CACHE_NAME = 'p2p-game-v3';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/menu.html',
-  '/connect.html',
-  '/game.html',
-  '/multiplayer.js',
-  '/vendor/qrcode.js',
-  '/vendor/jsqr.js',
-  '/manifest.json'
+  './',
+  './index.html',
+  './menu.html',
+  './connect.html',
+  './game.html',
+  './multiplayer.js',
+  './vendor/qrcode.js',
+  './vendor/jsqr.js',
+  './manifest.json'
 ];
 
 // Install event - cache resources
@@ -86,7 +86,7 @@ self.addEventListener('fetch', (event) => {
       .catch(() => {
         // Offline fallback
         if (event.request.destination === 'document') {
-          return caches.match('/menu.html');
+          return caches.match('./menu.html');
         }
       })
   );


### PR DESCRIPTION
## Summary
- Fix service worker cache list to use relative paths so offline caching works in subdirectories
- Register service worker on menu, connect, and game pages to enable offline mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a254333d0c83338f3ad1cda3965cf3