### PR TITLE
Fix fast wave spawning bug

### DIFF
--- a/wasm/include/effects/visual_effects.h
+++ b/wasm/include/effects/visual_effects.h
@@ -48,7 +48,7 @@ public:
         if (screenShakeDuration > 0) {
             screenShakeDuration -= deltaTime;
             
-            float shakeAmount = screenShakeIntensity * (screenShakeDuration / Config::SCREEN_SHAKE_DURATION);
+            float shakeAmount = screenShakeIntensity * (screenShakeDuration / (Config::SCREEN_SHAKE_DURATION / 1000.0f));
             screenShakeOffset.x = (rand() % 200 - 100) / 100.0f * shakeAmount;
             screenShakeOffset.y = (rand() % 200 - 100) / 100.0f * shakeAmount;
             
@@ -185,7 +185,7 @@ public:
     
     void addScreenShake(float intensity) {
         screenShakeIntensity = std::max(screenShakeIntensity, intensity);
-        screenShakeDuration = Config::SCREEN_SHAKE_DURATION;
+        screenShakeDuration = Config::SCREEN_SHAKE_DURATION / 1000.0f;  // Convert ms to seconds
     }
     
     Vector2 getScreenShakeOffset() const {

--- a/wasm/include/entities/enemy.h
+++ b/wasm/include/entities/enemy.h
@@ -92,7 +92,7 @@ public:
                     aiState = AIState::CHASING;
                 } else if (attackCooldown <= 0) {
                     // Attack logic handled in collision system
-                    attackCooldown = Config::WOLF_ATTACK_COOLDOWN;
+                    attackCooldown = Config::WOLF_ATTACK_COOLDOWN / 1000.0f;  // Convert ms to seconds
                 }
                 break;
                 

--- a/wasm/include/entities/player.h
+++ b/wasm/include/entities/player.h
@@ -72,7 +72,7 @@ public:
             boostDuration -= deltaTime;
             if (boostDuration <= 0) {
                 boosting = false;
-                boostCooldown = Config::PLAYER_BOOST_COOLDOWN;
+                boostCooldown = Config::PLAYER_BOOST_COOLDOWN / 1000.0f;  // Convert ms to seconds
             }
         } else if (boostCooldown > 0) {
             boostCooldown -= deltaTime;
@@ -95,7 +95,7 @@ public:
             attackCooldown -= deltaTime;
             if (attackCooldown <= 0) {
                 attacking = false;
-                attackCooldown = Config::SWORD_COOLDOWN;
+                attackCooldown = Config::SWORD_COOLDOWN / 1000.0f;  // Convert ms to seconds
             }
         } else if (attackCooldown > 0) {
             attackCooldown -= deltaTime;
@@ -107,7 +107,7 @@ public:
             if (rollDuration <= 0) {
                 rolling = false;
                 invulnerable = false;
-                rollCooldown = Config::ROLL_COOLDOWN;
+                rollCooldown = Config::ROLL_COOLDOWN / 1000.0f;  // Convert ms to seconds
             } else {
                 // Move in roll direction
                 position += rollDirection * Config::ROLL_SPEED_MULTIPLIER * (deltaTime / 16.0f);
@@ -147,7 +147,7 @@ public:
     void startBoost() {
         if (!boosting && boostCooldown <= 0 && energy >= 20) {
             boosting = true;
-            boostDuration = Config::PLAYER_BOOST_DURATION;
+            boostDuration = Config::PLAYER_BOOST_DURATION / 1000.0f;  // Convert ms to seconds
             energy -= 20;
         }
     }
@@ -155,7 +155,7 @@ public:
     void startBlock() {
         if (!blocking && blockCooldown <= 0 && !rolling) {
             blocking = true;
-            blockDuration = Config::SHIELD_DURATION;
+            blockDuration = Config::SHIELD_DURATION / 1000.0f;  // Convert ms to seconds
             blockStartTime = emscripten_get_now();
             perfectParryWindow = true;
         }
@@ -164,14 +164,14 @@ public:
     void endBlock() {
         blocking = false;
         perfectParryWindow = false;
-        blockCooldown = Config::SHIELD_COOLDOWN;
+        blockCooldown = Config::SHIELD_COOLDOWN / 1000.0f;  // Convert ms to seconds
     }
     
     void startAttack(float angle) {
         if (!attacking && attackCooldown <= 0 && energy >= Config::SWORD_ENERGY_COST) {
             attacking = true;
             attackAngle = angle;
-            attackCooldown = Config::SWORD_ANIMATION_TIME;
+            attackCooldown = Config::SWORD_ANIMATION_TIME / 1000.0f;  // Convert ms to seconds
             energy -= Config::SWORD_ENERGY_COST;
         }
     }
@@ -180,7 +180,7 @@ public:
         if (!rolling && rollCooldown <= 0 && energy >= Config::ROLL_ENERGY_COST) {
             rolling = true;
             rollDirection = direction.normalized();
-            rollDuration = Config::ROLL_DURATION;
+            rollDuration = Config::ROLL_DURATION / 1000.0f;  // Convert ms to seconds
             invulnerable = true;
             energy -= Config::ROLL_ENERGY_COST;
         }
@@ -196,7 +196,7 @@ public:
                 break;
             case PowerUpType::SHIELD:
                 hasShield = true;
-                shieldDuration = Config::POWERUP_DURATION;
+                shieldDuration = Config::POWERUP_DURATION / 1000.0f;  // Convert ms to seconds
                 break;
             case PowerUpType::SPEED:
                 speedMultiplier = 1.5f;
@@ -206,11 +206,11 @@ public:
                 break;
             case PowerUpType::RAPID_FIRE:
                 rapidFire = true;
-                rapidFireDuration = Config::POWERUP_DURATION;
+                rapidFireDuration = Config::POWERUP_DURATION / 1000.0f;  // Convert ms to seconds
                 break;
             case PowerUpType::MULTI_SHOT:
                 multiShot = true;
-                multiShotDuration = Config::POWERUP_DURATION;
+                multiShotDuration = Config::POWERUP_DURATION / 1000.0f;  // Convert ms to seconds
                 break;
         }
     }

--- a/wasm/include/entities/projectile.h
+++ b/wasm/include/entities/projectile.h
@@ -16,7 +16,7 @@ public:
         : Entity(EntityType::PROJECTILE, pos, Config::PROJECTILE_RADIUS),
           damage(dmg),
           speed(Config::PROJECTILE_SPEED),
-          lifetime(Config::PROJECTILE_LIFETIME),
+          lifetime(Config::PROJECTILE_LIFETIME / 1000.0f),  // Convert ms to seconds
           ownerId(owner),
           direction(dir.normalized()) {
         velocity = direction * speed;

--- a/wasm/include/systems/collision_system.h
+++ b/wasm/include/systems/collision_system.h
@@ -108,7 +108,7 @@ private:
             if (perfectParry) {
                 // Perfect parry - no damage, stun enemy
                 damage = 0;
-                enemy->stun(Config::PERFECT_PARRY_STUN_DURATION);
+                enemy->stun(Config::PERFECT_PARRY_STUN_DURATION / 1000.0f);  // Convert ms to seconds
                 player->energy = std::min(player->energy + Config::PERFECT_PARRY_ENERGY_RESTORE, 
                                         player->maxEnergy);
                 
@@ -129,7 +129,7 @@ private:
         if (damage > 0) {
             player->takeDamage(damage);
             player->invulnerable = true;
-            player->invulnerabilityTimer = Config::INVULNERABILITY_DURATION;
+            player->invulnerabilityTimer = Config::INVULNERABILITY_DURATION / 1000.0f;  // Convert ms to seconds
             
             // Knockback
             Vector2 knockback = (player->position - enemy->position).normalized() * 10;

--- a/wasm/include/systems/wave_system.h
+++ b/wasm/include/systems/wave_system.h
@@ -48,7 +48,7 @@ public:
             if (enemySpawnTimer <= 0 && enemiesSpawnedThisWave < enemiesRequiredThisWave) {
                 spawnEnemy(entities, worldWidth, worldHeight);
                 enemiesSpawnedThisWave++;
-                enemySpawnTimer = Config::ENEMY_SPAWN_RATE;
+                enemySpawnTimer = Config::ENEMY_SPAWN_RATE / 1000.0f;  // Convert ms to seconds
             }
             
             // Spawn wolves (after wave 3)
@@ -56,13 +56,13 @@ public:
                 wolvesSpawnedThisWave < wolvesRequiredThisWave) {
                 spawnWolf(entities, worldWidth, worldHeight);
                 wolvesSpawnedThisWave++;
-                wolfSpawnTimer = Config::WOLF_WAVE_SPAWN_DELAY;
+                wolfSpawnTimer = Config::WOLF_WAVE_SPAWN_DELAY / 1000.0f;  // Convert ms to seconds
             }
             
             // Spawn power-ups
             if (powerUpSpawnTimer <= 0) {
                 spawnPowerUp(entities, worldWidth, worldHeight);
-                powerUpSpawnTimer = Config::POWERUP_SPAWN_RATE;
+                powerUpSpawnTimer = Config::POWERUP_SPAWN_RATE / 1000.0f;  // Convert ms to seconds
             }
             
             // Check if wave is complete
@@ -94,7 +94,7 @@ public:
     void startNextWave() {
         currentWave++;
         waveActive = false;
-        waveTransitionTimer = Config::WAVE_TRANSITION_TIME;
+        waveTransitionTimer = Config::WAVE_TRANSITION_TIME / 1000.0f;  // Convert ms to seconds
         
         // Calculate enemies for next wave
         enemiesRequiredThisWave = 5 + currentWave * 2;


### PR DESCRIPTION
Convert all millisecond-based game timers to seconds to fix incorrect game pacing.

The game's `deltaTime` is passed in seconds, but many configuration constants (e.g., spawn rates, cooldowns, durations) were defined in milliseconds. This mismatch caused all time-dependent mechanics to operate significantly faster than intended. This PR converts these millisecond constants to seconds when used in calculations, ensuring correct game speed.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4ab4aec-47b9-41ca-9ffa-4e7b0484fbbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4ab4aec-47b9-41ca-9ffa-4e7b0484fbbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

