### PR TITLE
Fix smash impact game loading

### DIFF
--- a/game.html
+++ b/game.html
@@ -545,7 +545,7 @@
                 
                 // Load the fixed WASM module wrapper
                 const script = document.createElement('script');
-                script.src = './public/wasm-module-fix.js';
+                script.src = 'public/wasm-module-fix.js';
                 document.head.appendChild(script);
                 
                 // Wait for the script to load
@@ -970,7 +970,7 @@
             }
             
             initGame();
-            gameLoop();
+            requestAnimationFrame(gameLoop);
         };
         
         // Initialize game

--- a/public/wasm-module-fix.js
+++ b/public/wasm-module-fix.js
@@ -24,7 +24,7 @@ async function createFixedGameEngine() {
             // Locate the WASM file
             locateFile: (path) => {
                 if (path.endsWith('.wasm')) {
-                    return './public/game_engine.wasm';
+                    return 'public/game_engine.wasm';
                 }
                 return path;
             },
@@ -81,6 +81,7 @@ function createFallbackGameEngine() {
                 y,
                 vx: 0,
                 vy: 0,
+                radius: 20,
                 health: 100,
                 maxHealth: 100
             });
@@ -96,6 +97,7 @@ function createFallbackGameEngine() {
                 y,
                 vx: 0,
                 vy: 0,
+                radius: 15,
                 speed,
                 health: 50,
                 maxHealth: 50
@@ -112,6 +114,7 @@ function createFallbackGameEngine() {
                 y,
                 vx: 0,
                 vy: 0,
+                radius: 18,
                 speed: 3.0,
                 health: 75,
                 maxHealth: 75
@@ -157,6 +160,48 @@ function createFallbackGameEngine() {
         
         getEntities() {
             return this.entities;
+        }
+        
+        getAllEntities() {
+            // Return a copy of entities array with proper structure
+            return this.entities.map(e => ({
+                id: e.id,
+                type: e.type,
+                x: e.x,
+                y: e.y,
+                vx: e.vx || 0,
+                vy: e.vy || 0,
+                radius: e.radius || 20,
+                health: e.health || 100,
+                maxHealth: e.maxHealth || 100,
+                speed: e.speed || 0
+            }));
+        }
+        
+        checkCollisions() {
+            // Basic collision detection
+            const player = this.entities.find(e => e.type === 'player');
+            if (!player) return;
+            
+            for (const entity of this.entities) {
+                if (entity.type === 'enemy' || entity.type === 'wolf') {
+                    const dx = player.x - entity.x;
+                    const dy = player.y - entity.y;
+                    const dist = Math.sqrt(dx * dx + dy * dy);
+                    
+                    if (dist < 40) { // Basic collision radius
+                        player.health = Math.max(0, player.health - 1);
+                    }
+                }
+            }
+        }
+        
+        setJoystickInput(x, y) {
+            const player = this.entities.find(e => e.type === 'player');
+            if (player) {
+                player.vx = x * 300; // Speed multiplier
+                player.vy = y * 300;
+            }
         }
         
         delete() {

--- a/test-game.html
+++ b/test-game.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Game Test</title>
+</head>
+<body>
+    <h1>Game Test Page</h1>
+    <p>Test the game locally:</p>
+    <ul>
+        <li><a href="game.html">Main Game</a></li>
+        <li><a href="public/game_engine.wasm">Check WASM file</a></li>
+        <li><a href="public/wasm-module-fix.js">Check WASM Module Fix</a></li>
+    </ul>
+    
+    <h2>Console Test</h2>
+    <button onclick="testWASM()">Test WASM Loading</button>
+    <div id="result"></div>
+    
+    <script>
+        async function testWASM() {
+            const resultDiv = document.getElementById('result');
+            resultDiv.innerHTML = 'Testing WASM loading...<br>';
+            
+            try {
+                // Test loading the wasm-module-fix.js
+                const script = document.createElement('script');
+                script.src = 'public/wasm-module-fix.js';
+                document.head.appendChild(script);
+                
+                await new Promise((resolve, reject) => {
+                    script.onload = resolve;
+                    script.onerror = reject;
+                });
+                
+                resultDiv.innerHTML += '✅ wasm-module-fix.js loaded<br>';
+                
+                // Test creating the game engine
+                if (window.createFixedGameEngine) {
+                    resultDiv.innerHTML += 'Creating game engine...<br>';
+                    const wasmModule = await window.createFixedGameEngine();
+                    resultDiv.innerHTML += '✅ WASM module created<br>';
+                    
+                    if (wasmModule.GameEngine) {
+                        resultDiv.innerHTML += '✅ GameEngine class found<br>';
+                        const engine = new wasmModule.GameEngine(1920, 1080);
+                        resultDiv.innerHTML += '✅ Game engine instance created successfully!<br>';
+                    } else {
+                        resultDiv.innerHTML += '❌ GameEngine class not found<br>';
+                    }
+                } else {
+                    resultDiv.innerHTML += '❌ createFixedGameEngine function not found<br>';
+                }
+            } catch (error) {
+                resultDiv.innerHTML += `❌ Error: ${error.message}<br>`;
+                console.error('Full error:', error);
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes game loading on GitHub Pages by correcting WASM module paths and enhancing the JavaScript fallback engine.

The game failed to load players and enemies on GitHub Pages due to incorrect relative paths for the WASM module and its wrapper. Additionally, the JavaScript fallback implementation lacked crucial methods (like `getAllEntities` and collision detection) and entity properties (`radius`), preventing the game from rendering or functioning correctly when the WASM module was not available or failed to load. The `gameLoop` initialization was also corrected for proper animation frame handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-881589a2-527f-45cf-ae75-2265c3bb04e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-881589a2-527f-45cf-ae75-2265c3bb04e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

