### PR TITLE
Allow public WASM modules to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 *.wasm
 *.wasm.map
 *.js.map
+# Allow compiled WASM modules in public/
+!public/*.wasm
 
 # IDE files
 .vscode/


### PR DESCRIPTION
## Summary
- permit committing WebAssembly modules in `public/` by adding an exception to `.gitignore`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/SmashImpact/tests/test-game.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a734faccdc833395276a1fd35a3fd9