### PR TITLE
Fix duplicate 'on' definition in workflow

### DIFF
--- a/.github/workflows/build-optimized.yml
+++ b/.github/workflows/build-optimized.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Run every Sunday at midnight
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -187,8 +189,3 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-# Schedule weekly cache cleanup
-on:
-  schedule:
-    - cron: '0 0 * * 0'  # Run every Sunday at midnight


### PR DESCRIPTION
Merge duplicate `on:` sections in `build-optimized.yml` to resolve the 'on' is already defined error.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ea3e032-b470-4e90-9a9b-650084d8f896">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ea3e032-b470-4e90-9a9b-650084d8f896">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

