### PR TITLE
Fix CI workflow to correctly report test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,15 +44,7 @@ jobs:
 
     - name: Run tests with coverage
       run: |
-        npm run test:ci || true
-        # Ensure coverage files exist even if tests fail
-        mkdir -p coverage
-        if [ ! -f coverage/coverage-final.json ] || [ ! -s coverage/coverage-final.json ]; then
-          echo '{}' > coverage/coverage-final.json
-        fi
-        if [ ! -f coverage/lcov.info ]; then
-          touch coverage/lcov.info
-        fi
+        npm run test:ci
       env:
         NODE_ENV: test
         CI: true


### PR DESCRIPTION
Fixes `Run tests with coverage` step to fail on test failures and prevent dummy coverage file generation.

The previous configuration used `|| true` and generated dummy coverage files, causing the CI workflow to pass even when tests failed, effectively masking regressions and disabling a critical safeguard against broken code.

---
<a href="https://cursor.com/background-agent?bcId=bc-a34d9f59-4b7e-4337-9f29-fbf1c2431273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a34d9f59-4b7e-4337-9f29-fbf1c2431273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

