### PR TITLE
Restore push trigger for main branch tests

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,6 +1,8 @@
 name: Test Matrix
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:  # Allow manual runs


### PR DESCRIPTION
Add `push` trigger for `main` branch to `test-matrix.yml` to ensure automated tests run on direct pushes and prevent untested code from reaching `main`.

---
<a href="https://cursor.com/background-agent?bcId=bc-692e4c55-093e-4f4b-b186-373cb6dca7dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-692e4c55-093e-4f4b-b186-373cb6dca7dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

