### PR TITLE
Fix optional chaining assignment in wolf state machine

### DIFF
--- a/src/ai/wolf/state-machine.js
+++ b/src/ai/wolf/state-machine.js
@@ -236,7 +236,9 @@ export class WolfStateMachine {
                 this.context?.playHurtAnimation?.();
             },
             onExit: () => {
-                this.context?.wasHurt = false;
+                if (this.context) {
+                    this.context.wasHurt = false;
+                }
             }
         });
 
@@ -245,7 +247,9 @@ export class WolfStateMachine {
                 this.context?.playStunnedAnimation?.();
             },
             onExit: () => {
-                this.context?.isStunned = false;
+                if (this.context) {
+                    this.context.isStunned = false;
+                }
             }
         });
 

--- a/tests/wolf-state-machine-tests.js
+++ b/tests/wolf-state-machine-tests.js
@@ -1,0 +1,27 @@
+const { describe, test, expect } = require('@jest/globals');
+const { WolfStateMachine } = require('../src/ai/wolf/state-machine.js');
+const { WolfState } = require('../src/ai/wolf/config.js');
+
+describe('WolfStateMachine context cleanup', () => {
+    test('resets wasHurt flag when leaving HURT state', () => {
+        const context = { wasHurt: true };
+        const sm = new WolfStateMachine(WolfState.HURT, context);
+        sm.transitionTo(WolfState.IDLE);
+        expect(context.wasHurt).toBe(false);
+    });
+
+    test('resets isStunned flag when leaving STUNNED state', () => {
+        const context = { isStunned: true };
+        const sm = new WolfStateMachine(WolfState.STUNNED, context);
+        sm.transitionTo(WolfState.IDLE);
+        expect(context.isStunned).toBe(false);
+    });
+
+    test('onExit handlers do not throw when context is missing', () => {
+        const smHurt = new WolfStateMachine(WolfState.HURT);
+        const smStunned = new WolfStateMachine(WolfState.STUNNED);
+        expect(() => smHurt.transitionTo(WolfState.IDLE)).not.toThrow();
+        expect(() => smStunned.transitionTo(WolfState.IDLE)).not.toThrow();
+    });
+});
+


### PR DESCRIPTION
## Summary
- avoid optional chaining assignments that broke parsing under SES
- add tests ensuring `HURT` and `STUNNED` states clean up context flags safely

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a280270083338b76802cd9f11978