### PR TITLE
Handle uncaught syntax error

### DIFF
--- a/src/ai/wolf-integration-modular.js
+++ b/src/ai/wolf-integration-modular.js
@@ -187,7 +187,7 @@ export class WolfAIIntegration {
      */
     getSpawnPosition() {
         // Try to spawn away from players
-        if (this.gameState.players && this.gameState.players && players && players && players.length > 0) {
+        if (this.gameState.players && this.gameState.players.length > 0) {
             const player = this.gameState.players[0];
             const angle = Math.random() * Math.PI * 2;
             const distance = 15 + Math.random() * 10;

--- a/src/game/visual-effects.js
+++ b/src/game/visual-effects.js
@@ -168,7 +168,7 @@
       trail.points.unshift({ x, y, opacity: 1 });
       
       // Limit trail length
-      if (trail.points && trail.points && trail.points && trail.points.length > trail.maxLength) {
+      if (trail.points && trail.points.length > trail.maxLength) {
         trail.points.pop();
       }
       
@@ -354,7 +354,7 @@
 
     // Update trails
     this.trails = this.trails.filter(trail => {
-      return trail.points && points && points && points.length > 0;
+      return trail.points && trail.points.length > 0;
     });
   }
 
@@ -372,12 +372,12 @@
     
     // Render trails
     this.trails.forEach(trail => {
-      if (trail.points && trail.points && trail.points && trail.points.length < 2) return;
+      if (!trail.points || trail.points.length < 2) return;
       
       ctx.strokeStyle = trail.color;
       ctx.lineCap = 'round';
       
-      for (let i = 0; i < trail.points && trail.points && trail.points && trail.points.length - 1; i++) {
+      for (let i = 0; i < trail.points.length - 1; i++) {
         const p1 = trail.points[i];
         const p2 = trail.points[i + 1];
         


### PR DESCRIPTION
Fix `SyntaxError: unexpected garbage after module` by removing redundant variable repetitions in conditional statements.

The syntax error was caused by malformed conditional expressions (e.g., `trail.points && trail.points && trail.points.length`) where repeated variable names were interpreted as unexpected tokens by the JavaScript parser.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f0f9e9c-7389-4cee-b67e-05c8522c856d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f0f9e9c-7389-4cee-b67e-05c8522c856d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

