### PR TITLE
Build wolf ai wasm module with embind errors

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -74,7 +74,7 @@ jobs:
           # Create wasm output directory
           mkdir -p wasm
           
-          # Compile the main WASM module
+          # Compile the main WASM module with embind support
           em++ wolf_ai_wasm.cpp \
             -O3 \
             -s WASM=1 \
@@ -85,6 +85,7 @@ jobs:
             -s EXPORT_NAME='WolfAIModule' \
             -s ENVIRONMENT='web,worker' \
             -s SINGLE_FILE=0 \
+            --bind \
             -o wasm/wolf_ai.js
           
           echo "WASM build completed successfully!"

--- a/EMBIND_FIX_SUMMARY.md
+++ b/EMBIND_FIX_SUMMARY.md
@@ -1,0 +1,42 @@
+# Embind Linking Issue Fix Summary
+
+## Problem
+The GitHub Actions workflow was failing with undefined symbol errors for embind functions:
+- `_embind_register_class`
+- `_embind_register_class_constructor`
+- `_embind_register_class_property`
+- `_embind_register_class_function`
+
+## Root Cause
+The `wolf_ai_wasm.cpp` file uses Emscripten's embind feature (includes `<emscripten/bind.h>` and uses `EMSCRIPTEN_BINDINGS` macro), but the GitHub Actions workflow was not compiling with the required `--bind` flag.
+
+Additionally, the `build_wolf_ai.sh` script was incorrectly using both `-lembind` and `--bind` flags together, which can cause linking issues.
+
+## Solution Applied
+
+### 1. Fixed GitHub Actions Workflow (`.github/workflows/wasm-build.yml`)
+Added the `--bind` flag to the em++ compilation command in the "Build Wolf AI WASM module" step:
+```bash
+em++ wolf_ai_wasm.cpp \
+  ... other flags ...
+  --bind \
+  -o wasm/wolf_ai.js
+```
+
+### 2. Fixed build_wolf_ai.sh Script
+Removed the redundant `-lembind` flag and kept only `--bind`:
+```bash
+emcc wolf_ai_wasm.cpp \
+  ... other flags ...
+  --bind \  # Removed -lembind, kept only --bind
+  -o public/wolf_ai.js
+```
+
+## Key Points
+- When using Emscripten's embind feature, you only need the `--bind` flag
+- The `-lembind` flag is redundant and can cause linking issues
+- The `--bind` flag automatically links the necessary embind library
+- All other build scripts in the project were already correctly using only `--bind`
+
+## Next Steps
+The GitHub Actions workflow should now build successfully. The embind symbols will be properly linked when the `--bind` flag is used during compilation.

--- a/build_wolf_ai.sh
+++ b/build_wolf_ai.sh
@@ -25,7 +25,6 @@ emcc wolf_ai_wasm.cpp \
     -s ENVIRONMENT='web' \
     -s NO_EXIT_RUNTIME=1 \
     -s ASSERTIONS=1 \
-    -lembind \
     --bind \
     -o public/wolf_ai.js
 


### PR DESCRIPTION
Add `--bind` flag to WASM build and remove redundant `-lembind` to fix embind linking errors.

The build was failing with 'undefined symbol: _embind_register_class' and similar errors because `wolf_ai_wasm.cpp` uses Emscripten's embind feature, but the compilation command in the GitHub Actions workflow was missing the `--bind` flag. Additionally, `build_wolf_ai.sh` incorrectly used both `--bind` and `-lembind`, which is redundant and can cause issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-daa8539f-9d0b-496a-81c3-908677db3376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daa8539f-9d0b-496a-81c3-908677db3376">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

