### PR TITLE
Handle wasm module heap32 undefined error

### DIFF
--- a/game.html
+++ b/game.html
@@ -452,8 +452,10 @@
                     wasmModule.ccall('get_render_data', null, ['number'], [buffer]);
                     
                     const data = [];
+                    // Access HEAP32 through the module instance
+                    const HEAP32 = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
                     for (let i = 0; i < bufferSize; i++) {
-                        data.push(wasmModule.HEAP32[buffer / 4 + i]);
+                        data.push(HEAP32[buffer / 4 + i]);
                     }
                     
                     wasmModule._free(buffer);
@@ -737,8 +739,10 @@
             getPlayerStats(statsBuffer);
             
             const stats = [];
+            // Access HEAP32 through the module instance
+            const HEAP32 = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
             for (let i = 0; i < 12; i++) {
-                stats.push(wasmModule.HEAP32[statsBuffer / 4 + i]);
+                stats.push(HEAP32[statsBuffer / 4 + i]);
             }
             wasmModule._free(statsBuffer);
             
@@ -766,11 +770,13 @@
             getInventory(invBuffer);
             
             const inventory = [];
+            // Access HEAP32 through the module instance
+            const HEAP32_inv = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
             for (let i = 0; i < 20; i++) {
                 inventory.push({
-                    type: wasmModule.HEAP32[invBuffer / 4 + i * 3],
-                    quantity: wasmModule.HEAP32[invBuffer / 4 + i * 3 + 1],
-                    power: wasmModule.HEAP32[invBuffer / 4 + i * 3 + 2]
+                    type: HEAP32_inv[invBuffer / 4 + i * 3],
+                    quantity: HEAP32_inv[invBuffer / 4 + i * 3 + 1],
+                    power: HEAP32_inv[invBuffer / 4 + i * 3 + 2]
                 });
             }
             wasmModule._free(invBuffer);

--- a/index.html
+++ b/index.html
@@ -452,8 +452,10 @@
                     wasmModule.ccall('get_render_data', null, ['number'], [buffer]);
                     
                     const data = [];
+                    // Access HEAP32 through the module instance
+                    const HEAP32 = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
                     for (let i = 0; i < bufferSize; i++) {
-                        data.push(wasmModule.HEAP32[buffer / 4 + i]);
+                        data.push(HEAP32[buffer / 4 + i]);
                     }
                     
                     wasmModule._free(buffer);
@@ -737,8 +739,10 @@
             getPlayerStats(statsBuffer);
             
             const stats = [];
+            // Access HEAP32 through the module instance
+            const HEAP32 = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
             for (let i = 0; i < 12; i++) {
-                stats.push(wasmModule.HEAP32[statsBuffer / 4 + i]);
+                stats.push(HEAP32[statsBuffer / 4 + i]);
             }
             wasmModule._free(statsBuffer);
             
@@ -766,11 +770,13 @@
             getInventory(invBuffer);
             
             const inventory = [];
+            // Access HEAP32 through the module instance
+            const HEAP32_inv = new Int32Array(wasmModule.HEAPU8.buffer, 0, wasmModule.HEAPU8.length >> 2);
             for (let i = 0; i < 20; i++) {
                 inventory.push({
-                    type: wasmModule.HEAP32[invBuffer / 4 + i * 3],
-                    quantity: wasmModule.HEAP32[invBuffer / 4 + i * 3 + 1],
-                    power: wasmModule.HEAP32[invBuffer / 4 + i * 3 + 2]
+                    type: HEAP32_inv[invBuffer / 4 + i * 3],
+                    quantity: HEAP32_inv[invBuffer / 4 + i * 3 + 1],
+                    power: HEAP32_inv[invBuffer / 4 + i * 3 + 2]
                 });
             }
             wasmModule._free(invBuffer);


### PR DESCRIPTION
Fix `TypeError: wasmModule.HEAP32 is undefined` by correctly accessing WebAssembly memory in modern Emscripten.

The `wasmModule.HEAP32` property is no longer directly available on the module object in recent Emscripten versions. This change updates the JavaScript code to create a `Int32Array` view from `wasmModule.HEAPU8.buffer` to correctly read 32-bit integers from the WebAssembly memory, aligning with current Emscripten practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dddeb68-1e45-4711-8064-03e9f7fd5356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dddeb68-1e45-4711-8064-03e9f7fd5356">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

